### PR TITLE
Issue 1468 in connect-app - support for “[Who] responded to your post" notifications

### DIFF
--- a/connect/events-config.js
+++ b/connect/events-config.js
@@ -33,10 +33,11 @@ const TOPCODER_ROLE_RULES = {
  * Supported events configuration
  *
  * Each event configuration object has
- *   type          {String}  [mandatory] Event type
- *   projectRoles  {Array}   [optional]  List of project member roles which has to get notification
- *   topcoderRoles {Array}   [optional]  List of TopCoder member roles which has to get notification
- *   toUserHandle  {Boolean} [optional]  If set to true, user defined in `message.userHandle` will get notification
+ *   type           {String}  [mandatory] Event type
+ *   projectRoles   {Array}   [optional]  List of project member roles which has to get notification
+ *   topcoderRoles  {Array}   [optional]  List of TopCoder member roles which has to get notification
+ *   toUserHandle   {Boolean} [optional]  If set to true, user defined in `message.userHandle` will get notification
+ *   toTopicStarter {Boolean} [optional]  If set to true, than will find who started topic `message.topicId` and send notification to him
  *
  * @type {Array}
  */
@@ -96,7 +97,7 @@ const EVENTS = [
   }, {
     type: 'notifications.connect.project.post.created',
     projectRoles: [PROJECT_ROLE_OWNER, PROJECT_ROLE_COPILOT, PROJECT_ROLE_MANAGER, PROJECT_ROLE_MEMBER],
-    toUserHandle: true,
+    toTopicStarter: true,
   },
   {
     type: 'notifications.connect.project.linkCreated',

--- a/connect/service.js
+++ b/connect/service.js
@@ -18,7 +18,7 @@ const getProject = (projectId) => request
   .set('authorization', `Bearer ${config.TC_ADMIN_TOKEN}`)
   .then((res) => {
     if (!_.get(res, 'body.result.success')) {
-      throw new Error(`Failed to get project details of projectq id: ${projectId}`);
+      throw new Error(`Failed to get project details of project id: ${projectId}`);
     }
 
     const project = _.get(res, 'body.result.content');
@@ -59,6 +59,13 @@ const getRoleMembers = (roleId) => request
     );
   });
 
+/**
+ * Get users details by ids
+ *
+ * @param  {Array} ids list of user ids
+ *
+ * @return {Promise}   resolves to the list of user details
+ */
 const getUsersById = (ids) => {
   const query = _.map(ids, (id) => 'userId:' + id).join(' OR ');
   return request
@@ -82,8 +89,42 @@ const getUsersById = (ids) => {
     });
 };
 
+/**
+ * Get topic details
+ *
+ * @param  {String} topicId topic id
+ *
+ * @return {Promise}          promise resolved to topic details
+ */
+const getTopic = (topicId) => request
+  .get(`${config.TC_API_V4_BASE_URL}/topics/${topicId}`)
+  .set('accept', 'application/json')
+  .set('authorization', `Bearer ${config.TC_ADMIN_TOKEN}`)
+  .then((res) => {
+    if (!_.get(res, 'body.result.success')) {
+      throw new Error(`Failed to get topic details of topic id: ${topicId}`);
+    }
+
+    const topic = _.get(res, 'body.result.content');
+
+    // this API gives an array instead of one topic
+    if (topic.length < 1) {
+      throw new Error(`Failed to get topic details of topic id: ${topicId}`);
+    }
+
+    return topic[0];
+  }).catch((err) => {
+    const errorDetails = _.get(err, 'response.body.result.content.message');
+    throw new Error(
+      `Failed to get topic details of topic id: ${topicId}.` +
+      (errorDetails ? ' Server response: ' + errorDetails : '')
+    );
+  });
+
+
 module.exports = {
   getProject,
   getRoleMembers,
   getUsersById,
+  getTopic,
 };


### PR DESCRIPTION
[Issue 1468 in connect-app](https://github.com/appirio-tech/connect-app/issues/1468) - support for “[Who] responded to your post" notifications

## Possible issues
- In documentation in swagger for API v4 for `GET /topics/{topicId}` it states that we will get one topic in response https://github.com/topcoder-platform/tc-message-service/blob/dev/swagger.yaml#L258
  But this endpoint returns an array.