### PR TITLE
Issue 1554 in Connect App - User in notifications are listed with @handle instead of their name

### DIFF
--- a/connect/connectNotificationServer.js
+++ b/connect/connectNotificationServer.js
@@ -205,7 +205,7 @@ const handler = (topic, message, callback) => {
 
       // now let's retrieve some additional data
 
-      // if message has userId such messages will likely need userHandle
+      // if message has userId such messages will likely need userHandle and user full name
       // so let's get it
       if (message.userId) {
         const ids = [message.userId];
@@ -214,10 +214,12 @@ const handler = (topic, message, callback) => {
       return [];
     }).then((users) => {
       _.map(allNotifications, (notification) => {
+        notification.version = eventConfig.version;
         notification.contents.projectName = project.name;
         // if found a user then add user handle
         if (users.length) {
           notification.contents.userHandle = users[0].handle;
+          notification.contents.userFullName = `${users[0].firstName} ${users[0].lastName}`;
         }
       });
       callback(null, allNotifications);

--- a/connect/events-config.js
+++ b/connect/events-config.js
@@ -34,10 +34,12 @@ const TOPCODER_ROLE_RULES = {
  *
  * Each event configuration object has
  *   type           {String}  [mandatory] Event type
+ *   version        {Number}  [optional]  Version of the event.
  *   projectRoles   {Array}   [optional]  List of project member roles which has to get notification
  *   topcoderRoles  {Array}   [optional]  List of TopCoder member roles which has to get notification
  *   toUserHandle   {Boolean} [optional]  If set to true, user defined in `message.userHandle` will get notification
- *   toTopicStarter {Boolean} [optional]  If set to true, than will find who started topic `message.topicId` and send notification to him
+ *   toTopicStarter {Boolean} [optional]  If set to true, than will find who started topic `message.topicId` and
+ *                                        send notification to him
  *
  * @type {Array}
  */
@@ -73,13 +75,16 @@ const EVENTS = [
     projectRoles: [PROJECT_ROLE_OWNER, PROJECT_ROLE_COPILOT, PROJECT_ROLE_MANAGER],
   }, {
     type: 'notifications.connect.project.member.left',
+    version: 2,
     projectRoles: [PROJECT_ROLE_MANAGER],
   }, {
     type: 'notifications.connect.project.member.removed',
+    version: 2,
     projectRoles: [PROJECT_ROLE_MANAGER],
     toUserHandle: true,
   }, {
     type: 'notifications.connect.project.member.assignedAsOwner',
+    version: 2,
     projectRoles: [PROJECT_ROLE_COPILOT, PROJECT_ROLE_MANAGER],
     toUserHandle: true,
   }, {
@@ -93,20 +98,25 @@ const EVENTS = [
   // Project activity
   {
     type: 'notifications.connect.project.topic.created',
+    version: 2,
     projectRoles: [PROJECT_ROLE_OWNER, PROJECT_ROLE_COPILOT, PROJECT_ROLE_MANAGER, PROJECT_ROLE_MEMBER],
   }, {
     type: 'notifications.connect.project.post.created',
+    version: 2,
     projectRoles: [PROJECT_ROLE_OWNER, PROJECT_ROLE_COPILOT, PROJECT_ROLE_MANAGER, PROJECT_ROLE_MEMBER],
     toTopicStarter: true,
   },
   {
     type: 'notifications.connect.project.linkCreated',
+    version: 2,
     projectRoles: [PROJECT_ROLE_OWNER, PROJECT_ROLE_COPILOT, PROJECT_ROLE_MANAGER, PROJECT_ROLE_MEMBER],
   }, {
     type: 'notifications.connect.project.fileUploaded',
+    version: 2,
     projectRoles: [PROJECT_ROLE_OWNER, PROJECT_ROLE_COPILOT, PROJECT_ROLE_MANAGER, PROJECT_ROLE_MEMBER],
   }, {
     type: 'notifications.connect.project.specificationModified',
+    version: 2,
     projectRoles: [PROJECT_ROLE_OWNER, PROJECT_ROLE_COPILOT, PROJECT_ROLE_MANAGER, PROJECT_ROLE_MEMBER],
   },
 ];

--- a/src/app.js
+++ b/src/app.js
@@ -53,6 +53,7 @@ function startKafkaConsumer(handlers) {
       .then((notifications) => Promise.all(_.map(notifications, (notification) => models.Notification.create({
         userId: notification.userId,
         type: topicName,
+        version: notification.version || null,
         contents: _.extend({}, messageJSON, notification.contents),
         read: false,
       }))))

--- a/src/models/Notification.js
+++ b/src/models/Notification.js
@@ -16,6 +16,7 @@ module.exports = (sequelize, DataTypes) => sequelize.define('Notification', {
   type: { type: DataTypes.STRING, allowNull: false },
   contents: { type: DataTypes.JSONB, allowNull: false },
   read: { type: DataTypes.BOOLEAN, allowNull: false },
+  version: { type: DataTypes.SMALLINT, allowNull: true },
 }, {});
 
 // sequelize will generate and manage createdAt, updatedAt fields

--- a/src/services/NotificationService.js
+++ b/src/services/NotificationService.js
@@ -87,12 +87,11 @@ function* updateSettings(data, userId) {
  */
 function* listNotifications(query, userId) {
   const settings = yield getSettings(userId);
-  
 
   const filter = { where: {
     userId,
   }, offset: query.offset, limit: query.limit, order: [['createdAt', 'DESC']] };
-  if (_.keys(settings).length>0){
+  if (_.keys(settings).length > 0) {
     // only filter out notifications types which were explicitly set to 'no' - so we return notification by default
     const notificationTypes = _.keys(settings).filter((notificationType) => settings[notificationType].web !== 'no');
     filter.where.type = { $in: notificationTypes };


### PR DESCRIPTION
Issue [1554](https://github.com/appirio-tech/connect-app/issues/1554) in Connect App - User in notifications are listed with @handle instead of their name

- add support for notification versions
- add user full name to notification body if userId is provided