### PR TITLE
Fix posts links in email notifications

### DIFF
--- a/emails/src/partials/topics_and_posts.html
+++ b/emails/src/partials/topics_and_posts.html
@@ -170,7 +170,7 @@
             <tr>
                 <td class="empty-child-one"></td>
                 <td class="second-child" align="center">
-                <a href="{{@root.connectURL}}/projects/{{notifications.[0].projectId}}#feed-{{notifications.[0].topicId}}">
+                <a href="{{notifications.[0].postURL}}">
                     View post on Connect
                 </a>
                 </td>
@@ -196,7 +196,7 @@
     <tr class="copy-link">
         <td class="main-td">
             <table class="main-child">
-            <tr><td><a href="{{@root.connectURL}}/projects/{{notifications.[0].projectId}}#feed-{{notifications.[0].topicId}}">{{@root.connectURL}}/projects/{{notifications.[0].projectId}}#feed-{{notifications.[0].topicId}}</a></td></tr>
+            <tr><td><a href="{{notifications.[0].postURL}}">{{notifications.[0].postURL}}</a></td></tr>
             </table>  
         </td>
     </tr>


### PR DESCRIPTION
fix links for dashboard topics, posts, and for phase posts in emails

To fully apply this PR we would need to update sendgrid templates.

I've noticed there is a [PR](https://github.com/topcoder-platform/tc-notifications/pull/64) to automatically update sendgrid templates, but it's not yet merged.